### PR TITLE
Use model namespace in chopping board

### DIFF
--- a/src/main/java/com/github/ysbbbbbb/kaleidoscopecookery/client/render/block/ChoppingBoardBlockEntityRender.java
+++ b/src/main/java/com/github/ysbbbbbb/kaleidoscopecookery/client/render/block/ChoppingBoardBlockEntityRender.java
@@ -33,7 +33,7 @@ public class ChoppingBoardBlockEntityRender implements BlockEntityRenderer<Chopp
             choppingBoard.previousModel = modelId;
             choppingBoard.cacheModels = new ResourceLocation[choppingBoard.getMaxCutCount() + 1];
             for (int i = 0; i <= choppingBoard.getMaxCutCount(); i++) {
-                choppingBoard.cacheModels[i] = new ResourceLocation(KaleidoscopeCookery.MOD_ID, "chopping_board/" + modelId.getPath() + "/" + i);
+                choppingBoard.cacheModels[i] = new ResourceLocation(modelId.getNamespace(), "chopping_board/" + modelId.getPath() + "/" + i);
             }
         }
         if (choppingBoard.cacheModels == null) {


### PR DESCRIPTION
This allows putting models in a custom namespace if creating content in addons or in KubeJS