### PR TITLE
chore(deps): 更新 KubeJS 和 Rhino 依赖版本并修复问题

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -137,8 +137,8 @@ dependencies {
     implementation "maven.modrinth:jade:15.0.5+neoforge"
 
     // KubeJS
-    implementation "dev.latvian.mods:rhino:2101.2.7-build.72"
-    implementation "dev.latvian.mods:kubejs-neoforge:2101.7.1-build.181"
+    implementation "dev.latvian.mods:rhino:2101.2.7-build.81"
+    implementation "dev.latvian.mods:kubejs-neoforge:2101.7.2-build.329"
     runtimeOnly "com.github.rtyley:animated-gif-lib-for-java:animated-gif-lib-1.7"
     runtimeOnly "curse.maven:probejs-585406:5820894"
 

--- a/src/main/java/com/github/ysbbbbbb/kaleidoscopecookery/compat/kubejs/recipe/ChoppingBoardRecipeSchema.java
+++ b/src/main/java/com/github/ysbbbbbb/kaleidoscopecookery/compat/kubejs/recipe/ChoppingBoardRecipeSchema.java
@@ -11,7 +11,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
 
 public interface ChoppingBoardRecipeSchema {
-    RecipeKey<ItemStack> OUTPUT = ItemStackComponent.STRICT_ITEM_STACK.outputKey("result");
+    RecipeKey<ItemStack> OUTPUT = ItemStackComponent.ITEM_STACK.outputKey("result");
     RecipeKey<Ingredient> INGREDIENT = IngredientComponent.INGREDIENT.inputKey("ingredient");
     RecipeKey<String> MODEL_ID = StringComponent.ID.otherKey("model_id");
     RecipeKey<Integer> CUT_COUNT = NumberComponent.INT.otherKey("cut_count").optional(4);

--- a/src/main/java/com/github/ysbbbbbb/kaleidoscopecookery/compat/kubejs/recipe/MillstoneRecipeSchema.java
+++ b/src/main/java/com/github/ysbbbbbb/kaleidoscopecookery/compat/kubejs/recipe/MillstoneRecipeSchema.java
@@ -8,7 +8,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
 
 public interface MillstoneRecipeSchema {
-    RecipeKey<ItemStack> OUTPUT = ItemStackComponent.STRICT_ITEM_STACK.outputKey("result");
+    RecipeKey<ItemStack> OUTPUT = ItemStackComponent.ITEM_STACK.outputKey("result");
     RecipeKey<Ingredient> INGREDIENT = IngredientComponent.INGREDIENT.inputKey("ingredient");
 
     RecipeSchema SCHEMA = new RecipeSchema(OUTPUT, INGREDIENT);

--- a/src/main/java/com/github/ysbbbbbb/kaleidoscopecookery/compat/kubejs/recipe/PotRecipeSchema.java
+++ b/src/main/java/com/github/ysbbbbbb/kaleidoscopecookery/compat/kubejs/recipe/PotRecipeSchema.java
@@ -1,5 +1,6 @@
 package com.github.ysbbbbbb.kaleidoscopecookery.compat.kubejs.recipe;
 
+import com.github.ysbbbbbb.kaleidoscopecookery.compat.kubejs.util.IngredientListComponent;
 import dev.latvian.mods.kubejs.recipe.RecipeKey;
 import dev.latvian.mods.kubejs.recipe.component.IngredientComponent;
 import dev.latvian.mods.kubejs.recipe.component.ItemStackComponent;
@@ -11,8 +12,8 @@ import net.minecraft.world.item.crafting.Ingredient;
 import java.util.List;
 
 public interface PotRecipeSchema {
-    RecipeKey<ItemStack> OUTPUT = ItemStackComponent.STRICT_ITEM_STACK.outputKey("result");
-    RecipeKey<List<Ingredient>> INGREDIENTS = IngredientComponent.INGREDIENT.asList().inputKey("ingredients");
+    RecipeKey<ItemStack> OUTPUT = ItemStackComponent.ITEM_STACK.outputKey("result");
+    RecipeKey<List<Ingredient>> INGREDIENTS = IngredientListComponent.TYPE.inputKey("ingredients");
     RecipeKey<Ingredient> CARRIER = IngredientComponent.INGREDIENT.inputKey("carrier").optional(Ingredient.EMPTY);
     RecipeKey<Integer> TIME = NumberComponent.INT.otherKey("time").optional(200);
     RecipeKey<Integer> STIR_FRY_COUNT = NumberComponent.INT.otherKey("stir_fry_count").optional(3);

--- a/src/main/java/com/github/ysbbbbbb/kaleidoscopecookery/compat/kubejs/recipe/SteamerRecipeSchema.java
+++ b/src/main/java/com/github/ysbbbbbb/kaleidoscopecookery/compat/kubejs/recipe/SteamerRecipeSchema.java
@@ -9,7 +9,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
 
 public interface SteamerRecipeSchema {
-    RecipeKey<ItemStack> OUTPUT = ItemStackComponent.STRICT_ITEM_STACK.outputKey("result");
+    RecipeKey<ItemStack> OUTPUT = ItemStackComponent.ITEM_STACK.outputKey("result");
     RecipeKey<Ingredient> INGREDIENT = IngredientComponent.INGREDIENT.inputKey("ingredient");
     RecipeKey<Integer> COOK_TICK = NumberComponent.INT.otherKey("cook_tick").optional(60 * 20);
 

--- a/src/main/java/com/github/ysbbbbbb/kaleidoscopecookery/compat/kubejs/recipe/StockpotRecipeSchema.java
+++ b/src/main/java/com/github/ysbbbbbb/kaleidoscopecookery/compat/kubejs/recipe/StockpotRecipeSchema.java
@@ -1,5 +1,6 @@
 package com.github.ysbbbbbb.kaleidoscopecookery.compat.kubejs.recipe;
 
+import com.github.ysbbbbbb.kaleidoscopecookery.compat.kubejs.util.IngredientListComponent;
 import dev.latvian.mods.kubejs.recipe.RecipeKey;
 import dev.latvian.mods.kubejs.recipe.component.IngredientComponent;
 import dev.latvian.mods.kubejs.recipe.component.ItemStackComponent;
@@ -14,8 +15,8 @@ import java.util.List;
 import static com.github.ysbbbbbb.kaleidoscopecookery.crafting.serializer.StockpotRecipeSerializer.*;
 
 public interface StockpotRecipeSchema {
-    RecipeKey<ItemStack> OUTPUT = ItemStackComponent.STRICT_ITEM_STACK.outputKey("result");
-    RecipeKey<List<Ingredient>> INGREDIENTS = IngredientComponent.INGREDIENT.asList().inputKey("ingredients");
+    RecipeKey<ItemStack> OUTPUT = ItemStackComponent.ITEM_STACK.outputKey("result");
+    RecipeKey<List<Ingredient>> INGREDIENTS = IngredientListComponent.TYPE.inputKey("ingredients");
     RecipeKey<String> SOUP_BASE = StringComponent.ID.inputKey("soup_base").optional(DEFAULT_SOUP_BASE.toString());
     RecipeKey<Integer> TIME = NumberComponent.INT.otherKey("time").optional(DEFAULT_TIME);
     RecipeKey<Ingredient> CARRIER = IngredientComponent.INGREDIENT.inputKey("carrier").optional(DEFAULT_CARRIER);

--- a/src/main/java/com/github/ysbbbbbb/kaleidoscopecookery/compat/kubejs/util/IngredientListComponent.java
+++ b/src/main/java/com/github/ysbbbbbb/kaleidoscopecookery/compat/kubejs/util/IngredientListComponent.java
@@ -1,0 +1,41 @@
+package com.github.ysbbbbbb.kaleidoscopecookery.compat.kubejs.util;
+
+import com.github.ysbbbbbb.kaleidoscopecookery.KaleidoscopeCookery;
+import com.mojang.serialization.Codec;
+import dev.latvian.mods.kubejs.recipe.component.RecipeComponent;
+import dev.latvian.mods.kubejs.recipe.component.RecipeComponentType;
+import dev.latvian.mods.rhino.type.TypeInfo;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.crafting.Ingredient;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+public record IngredientListComponent() implements RecipeComponent<List<Ingredient>> {
+    public static final IngredientListComponent INSTANCE = new IngredientListComponent();
+    public static final Codec<List<Ingredient>> CONTENT_CODEC = Ingredient.LIST_CODEC;
+    public static final RecipeComponentType<List<Ingredient>> TYPE = RecipeComponentType.unit(
+        ResourceLocation.fromNamespaceAndPath(KaleidoscopeCookery.MOD_ID, "ingredient_list"),
+        INSTANCE
+    );
+
+    @Override
+    public RecipeComponentType<?> type() {
+        return TYPE;
+    }
+
+    @Override
+    public Codec<List<Ingredient>> codec() {
+        return IngredientListComponent.CONTENT_CODEC;
+    }
+
+    @Override
+    public TypeInfo typeInfo() {
+        return TypeInfo.of(List.class);
+    }
+
+    @Override
+    public @NotNull String toString() {
+        return "ingredient_list";
+    }
+}


### PR DESCRIPTION
- fixed #101
- 将 Rhino 从 build.72 更新至 build.81
- 将 KubeJS-NeoForge 从 build.181 更新至 build.329
- 修改 ChoppingBoardRecipeSchema 使用 ITEM_STACK 组件
- 修改 MillstoneRecipeSchema 使用 ITEM_STACK 组件
- 修改 PotRecipeSchema 使用 OPTIONAL_ITEM_STACK 组件并引入 IngredientListComponent
- 修改 SteamerRecipeSchema 使用 ITEM_STACK 组件
- 修改 StockpotRecipeSchema 使用 ITEM_STACK 组件并引入 IngredientListComponent
- 新增 IngredientListComponent 用于处理 Ingredient 列表序列化