### PR TITLE
添加食物状态效果显示配置

### DIFF
--- a/src/main/java/com/github/ysbbbbbb/kaleidoscopecookery/KaleidoscopeCookery.java
+++ b/src/main/java/com/github/ysbbbbbb/kaleidoscopecookery/KaleidoscopeCookery.java
@@ -1,5 +1,6 @@
 package com.github.ysbbbbbb.kaleidoscopecookery;
 
+import com.github.ysbbbbbb.kaleidoscopecookery.config.ClientConfig;
 import com.github.ysbbbbbb.kaleidoscopecookery.config.GeneralConfig;
 import com.github.ysbbbbbb.kaleidoscopecookery.init.*;
 import com.github.ysbbbbbb.kaleidoscopecookery.init.registry.FoodBiteRegistry;
@@ -19,6 +20,7 @@ public class KaleidoscopeCookery {
     public KaleidoscopeCookery() {
         IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
         ModLoadingContext.get().registerConfig(ModConfig.Type.COMMON, GeneralConfig.init());
+        ModLoadingContext.get().registerConfig(ModConfig.Type.CLIENT, ClientConfig.init());
 
         FoodBiteRegistry.init();
         ModTrigger.init();

--- a/src/main/java/com/github/ysbbbbbb/kaleidoscopecookery/config/ClientConfig.java
+++ b/src/main/java/com/github/ysbbbbbb/kaleidoscopecookery/config/ClientConfig.java
@@ -12,7 +12,7 @@ public class ClientConfig {
     public static ForgeConfigSpec.BooleanValue SHOW_FOOD_EFFECT_TOOLTIPS;
 
     private static void client(ForgeConfigSpec.Builder builder) {
-        builder.push("client");
+        builder.push("cookery");
 
         builder.comment("Whether to show food effect tooltips when hovering over food items.");
         SHOW_FOOD_EFFECT_TOOLTIPS = builder.define("ShowFoodEffectTooltips", true);

--- a/src/main/java/com/github/ysbbbbbb/kaleidoscopecookery/config/ClientConfig.java
+++ b/src/main/java/com/github/ysbbbbbb/kaleidoscopecookery/config/ClientConfig.java
@@ -1,0 +1,22 @@
+package com.github.ysbbbbbb.kaleidoscopecookery.config;
+
+import net.minecraftforge.common.ForgeConfigSpec;
+
+public class ClientConfig {
+    public static ForgeConfigSpec init() {
+        ForgeConfigSpec.Builder builder = new ForgeConfigSpec.Builder();
+        client(builder);
+        return builder.build();
+    }
+
+    public static ForgeConfigSpec.BooleanValue SHOW_FOOD_EFFECT_TOOLTIPS;
+
+    private static void client(ForgeConfigSpec.Builder builder) {
+        builder.push("client");
+
+        builder.comment("Whether to show food effect tooltips when hovering over food items.");
+        SHOW_FOOD_EFFECT_TOOLTIPS = builder.define("ShowFoodEffectTooltips", true);
+
+        builder.pop();
+    }
+}

--- a/src/main/java/com/github/ysbbbbbb/kaleidoscopecookery/config/GeneralConfig.java
+++ b/src/main/java/com/github/ysbbbbbb/kaleidoscopecookery/config/GeneralConfig.java
@@ -16,7 +16,7 @@ public class GeneralConfig {
     public static ForgeConfigSpec.BooleanValue SATIATED_SHIELD_ABSORB_EXCESS_DAMAGE;
 
     private static void general(ForgeConfigSpec.Builder builder) {
-        builder.push("effect");
+        builder.push("cookery");
 
         builder.comment("Whether enabling the Satiated Shield effect.");
         SATIATED_SHIELD_ABSORB_ENABLED = builder.define("SatiatedShieldAbsorbEnabled", true);

--- a/src/main/java/com/github/ysbbbbbb/kaleidoscopecookery/config/GeneralConfig.java
+++ b/src/main/java/com/github/ysbbbbbb/kaleidoscopecookery/config/GeneralConfig.java
@@ -16,7 +16,7 @@ public class GeneralConfig {
     public static ForgeConfigSpec.BooleanValue SATIATED_SHIELD_ABSORB_EXCESS_DAMAGE;
 
     private static void general(ForgeConfigSpec.Builder builder) {
-        builder.push("cookery");
+        builder.push("effect");
 
         builder.comment("Whether enabling the Satiated Shield effect.");
         SATIATED_SHIELD_ABSORB_ENABLED = builder.define("SatiatedShieldAbsorbEnabled", true);

--- a/src/main/java/com/github/ysbbbbbb/kaleidoscopecookery/item/BowlFoodBlockItem.java
+++ b/src/main/java/com/github/ysbbbbbb/kaleidoscopecookery/item/BowlFoodBlockItem.java
@@ -2,6 +2,7 @@ package com.github.ysbbbbbb.kaleidoscopecookery.item;
 
 import com.github.ysbbbbbb.kaleidoscopecookery.api.item.IHasContainer;
 import com.github.ysbbbbbb.kaleidoscopecookery.block.food.FoodBiteBlock;
+import com.github.ysbbbbbb.kaleidoscopecookery.config.ClientConfig;
 import com.github.ysbbbbbb.kaleidoscopecookery.init.registry.CompatRegistry;
 import com.google.common.collect.Lists;
 import net.minecraft.ChatFormatting;
@@ -82,7 +83,7 @@ public class BowlFoodBlockItem extends BlockItem implements IHasContainer {
                 }
             }
         }
-        if (!this.effectInstances.isEmpty() && CompatRegistry.SHOW_POTION_EFFECT_TOOLTIPS) {
+        if (!this.effectInstances.isEmpty() && CompatRegistry.SHOW_POTION_EFFECT_TOOLTIPS && ClientConfig.SHOW_FOOD_EFFECT_TOOLTIPS.get()) {
             tooltip.add(CommonComponents.space());
             PotionUtils.addPotionTooltip(this.effectInstances, tooltip, 1.0F);
         }

--- a/src/main/java/com/github/ysbbbbbb/kaleidoscopecookery/item/FoodWithEffectsItem.java
+++ b/src/main/java/com/github/ysbbbbbb/kaleidoscopecookery/item/FoodWithEffectsItem.java
@@ -1,5 +1,6 @@
 package com.github.ysbbbbbb.kaleidoscopecookery.item;
 
+import com.github.ysbbbbbb.kaleidoscopecookery.config.ClientConfig;
 import com.github.ysbbbbbb.kaleidoscopecookery.init.registry.CompatRegistry;
 import com.google.common.collect.Lists;
 import net.minecraft.ChatFormatting;
@@ -47,7 +48,7 @@ public class FoodWithEffectsItem extends Item {
                 }
             }
         }
-        if (!this.effectInstances.isEmpty() && CompatRegistry.SHOW_POTION_EFFECT_TOOLTIPS) {
+        if (!this.effectInstances.isEmpty() && CompatRegistry.SHOW_POTION_EFFECT_TOOLTIPS && ClientConfig.SHOW_FOOD_EFFECT_TOOLTIPS.get()) {
             tooltip.add(CommonComponents.space());
             PotionUtils.addPotionTooltip(this.effectInstances, tooltip, 1.0F);
         }


### PR DESCRIPTION
https://github.com/KaleidoscopeMods/KaleidoscopeCookery/issues/165
以解决更多添加了状态效果显示的模组而无法单独关闭某一方的问题

原本
<img width="492" height="282" alt="image" src="https://github.com/user-attachments/assets/807bda10-89e5-40f8-8e35-762b4e73135d" />

更改后
<img width="919" height="241" alt="image" src="https://github.com/user-attachments/assets/c5c0c9fa-a24d-475c-86fd-843a107378ac" />
<img width="516" height="223" alt="image" src="https://github.com/user-attachments/assets/0360ea26-20b8-4560-8f8b-4e09b3949911" />
