### PR TITLE
为饱腹代偿提供更一些精细的配置项。

### DIFF
--- a/src/main/java/com/github/ysbbbbbb/kaleidoscopecookery/config/GeneralConfig.java
+++ b/src/main/java/com/github/ysbbbbbb/kaleidoscopecookery/config/GeneralConfig.java
@@ -15,6 +15,24 @@ public class GeneralConfig {
     public static ForgeConfigSpec.BooleanValue SATIATED_SHIELD_ABSORB_ENABLED;
     public static ForgeConfigSpec.BooleanValue SATIATED_SHIELD_ABSORB_EXCESS_DAMAGE;
 
+    /**
+     * 为饱腹代偿提供更一些精细的配置项。
+     */
+    // 玩家处于饥饿状态效果时，饱腹代偿是否失效。
+    public static ForgeConfigSpec.BooleanValue IS_SATIATED_SHIELD_DISABLE_WHEN_HUNGRY_EFFECT;
+    // 触发饱腹代偿效果所需的最小食物等级。
+    public static ForgeConfigSpec.IntValue SATIATED_SHIELD_MIN_FOOD_LEVEL;
+    // 饱腹代偿每吸收一点伤害所需的基础 Exhaustion 数值。
+    public static ForgeConfigSpec.DoubleValue SATIATED_SHIELD_ADDITIONAL_EXHAUSTION_PER_DAMAGE;
+    // 饱腹代偿效果的伤害减免百分比。
+    public static ForgeConfigSpec.DoubleValue SATIATED_SHIELD_DAMAGE_REDUCTION_PERCENT;
+    // 饱腹代偿效果的最大伤害减免量。
+    public static ForgeConfigSpec.DoubleValue SATIATED_SHIELD_MAX_DAMAGE_REDUCTION;
+    // 饱腹代偿效果下可造成的最小伤害。
+    public static ForgeConfigSpec.DoubleValue SATIATED_SHIELD_MIN_DAMAGE;
+    // 当玩家受到饱腹代偿弱点伤害时，每点伤害增加的疲劳值的乘算倍率。
+    public static ForgeConfigSpec.DoubleValue SATIATED_SHIELD_WEAKNESS_DAMAGE_MULTIPLIER;
+
     private static void general(ForgeConfigSpec.Builder builder) {
         builder.push("cookery");
 
@@ -23,6 +41,28 @@ public class GeneralConfig {
 
         builder.comment("Whether the Satiated Shield effect should absorb excess damage beyond its capacity.");
         SATIATED_SHIELD_ABSORB_EXCESS_DAMAGE = builder.define("SatiatedShieldAbsorbExcessDamage", true);
+
+        builder.comment("If true, the Satiated Shield effect will not apply while the player has the Hunger effect.");
+        IS_SATIATED_SHIELD_DISABLE_WHEN_HUNGRY_EFFECT = builder.define("IS_SATIATED_SHIELD_DISABLE_WHEN_HUNGRY_EFFECT", true);
+
+        builder.comment("Minimum Hunger Value required for the Satiated Shield to apply (int).");
+        SATIATED_SHIELD_MIN_FOOD_LEVEL = builder.defineInRange("SATIATED_SHIELD_MIN_FOOD_LEVEL", 1, 1, 20);
+
+        // 由于在 1 游戏刻中玩家最多积累 40 点疲劳值，因此该配置项大于 40 就没有意义了。
+        builder.comment("The exhaustion added each time the player takes damage.");
+        SATIATED_SHIELD_ADDITIONAL_EXHAUSTION_PER_DAMAGE = builder.defineInRange("SATIATED_SHIELD_ADDITIONAL_EXHAUSTION_PER_DAMAGE", 2.0, 0.0, 40.0);
+
+        builder.comment("The damage reduction percentage of the Satiated Shield effect.");
+        SATIATED_SHIELD_DAMAGE_REDUCTION_PERCENT = builder.defineInRange("SATIATED_SHIELD_DAMAGE_REDUCTION_PERCENT", 1.0, 0.0, 1.0);
+
+        builder.comment("The maximum damage reduction amount of the Satiated Shield effect.");
+        SATIATED_SHIELD_MAX_DAMAGE_REDUCTION = builder.defineInRange("SATIATED_SHIELD_MAX_DAMAGE_REDUCTION", 64.0, 0.0, Integer.MAX_VALUE);
+
+        builder.comment("The minimum damage that can be got in the Satiated Shield effect.");
+        SATIATED_SHIELD_MIN_DAMAGE = builder.defineInRange("SATIATED_SHIELD_MIN_DAMAGE", 16.0, 0.0, Integer.MAX_VALUE);
+
+        builder.comment("The multiplier for the exhaustion added per point of Satiated Shield Weakness Damage.");
+        SATIATED_SHIELD_WEAKNESS_DAMAGE_MULTIPLIER = builder.defineInRange("SATIATED_SHIELD_WEAKNESS_DAMAGE_MULTIPLIER", 2.0, 1.0, Integer.MAX_VALUE);
 
         builder.pop();
     }

--- a/src/main/java/com/github/ysbbbbbb/kaleidoscopecookery/config/GeneralConfig.java
+++ b/src/main/java/com/github/ysbbbbbb/kaleidoscopecookery/config/GeneralConfig.java
@@ -17,18 +17,22 @@ public class GeneralConfig {
 
     /**
      * 为饱腹代偿提供更一些精细的配置项。
+     * 实际体验的效果为：
+     * 伤害不超过 最小伤害 时可以完全抗伤，只受到 最终伤害 * ( 1 - 伤害减免百分比 ) 的伤害；
+     * 伤害不超过 最大伤害减免量 / 伤害减免百分比 时有 伤害减免百分比 的抗伤能力；
+     * 伤害超过 最大伤害减免量 / 伤害减免百分比 时抗伤能力显著下降。
      */
     // 玩家处于饥饿状态效果时，饱腹代偿是否失效。
     public static ForgeConfigSpec.BooleanValue IS_SATIATED_SHIELD_DISABLE_WHEN_HUNGRY_EFFECT;
-    // 触发饱腹代偿效果所需的最小食物等级。
+    // 触发饱腹代偿效果所需的最小食物等级，越高说明饱腹代偿的触发条件越苛刻。
     public static ForgeConfigSpec.IntValue SATIATED_SHIELD_MIN_FOOD_LEVEL;
     // 饱腹代偿每吸收一点伤害所需的基础 Exhaustion 数值。
     public static ForgeConfigSpec.DoubleValue SATIATED_SHIELD_ADDITIONAL_EXHAUSTION_PER_DAMAGE;
-    // 饱腹代偿效果的伤害减免百分比。
+    // 饱腹代偿效果的伤害减免百分比，不满 1 则必定会受到一部分伤害，越高说明饱腹代偿的抗伤能力越强。
     public static ForgeConfigSpec.DoubleValue SATIATED_SHIELD_DAMAGE_REDUCTION_PERCENT;
-    // 饱腹代偿效果的最大伤害减免量。
+    // 饱腹代偿效果的最大伤害减免量，影响面对伤害较高时的抗伤表现，越高说明饱腹代偿的抗伤能力越强。
     public static ForgeConfigSpec.DoubleValue SATIATED_SHIELD_MAX_DAMAGE_REDUCTION;
-    // 饱腹代偿效果下可造成的最小伤害。
+    // 饱腹代偿效果下可造成的最小伤害，影响面对伤害较低时的抗伤表现，越高说明饱腹代偿的抗伤能力越强。
     public static ForgeConfigSpec.DoubleValue SATIATED_SHIELD_MIN_DAMAGE;
     // 当玩家受到饱腹代偿弱点伤害时，每点伤害增加的疲劳值的乘算倍率。
     public static ForgeConfigSpec.DoubleValue SATIATED_SHIELD_WEAKNESS_DAMAGE_MULTIPLIER;
@@ -46,7 +50,7 @@ public class GeneralConfig {
         IS_SATIATED_SHIELD_DISABLE_WHEN_HUNGRY_EFFECT = builder.define("IS_SATIATED_SHIELD_DISABLE_WHEN_HUNGRY_EFFECT", true);
 
         builder.comment("Minimum Hunger Value required for the Satiated Shield to apply (int).");
-        SATIATED_SHIELD_MIN_FOOD_LEVEL = builder.defineInRange("SATIATED_SHIELD_MIN_FOOD_LEVEL", 1, 1, 20);
+        SATIATED_SHIELD_MIN_FOOD_LEVEL = builder.defineInRange("SATIATED_SHIELD_MIN_FOOD_LEVEL", 4, 1, 20);
 
         // 由于在 1 游戏刻中玩家最多积累 40 点疲劳值，因此该配置项大于 40 就没有意义了。
         builder.comment("The exhaustion added each time the player takes damage.");
@@ -56,10 +60,10 @@ public class GeneralConfig {
         SATIATED_SHIELD_DAMAGE_REDUCTION_PERCENT = builder.defineInRange("SATIATED_SHIELD_DAMAGE_REDUCTION_PERCENT", 1.0, 0.0, 1.0);
 
         builder.comment("The maximum damage reduction amount of the Satiated Shield effect.");
-        SATIATED_SHIELD_MAX_DAMAGE_REDUCTION = builder.defineInRange("SATIATED_SHIELD_MAX_DAMAGE_REDUCTION", 64.0, 0.0, Integer.MAX_VALUE);
+        SATIATED_SHIELD_MAX_DAMAGE_REDUCTION = builder.defineInRange("SATIATED_SHIELD_MAX_DAMAGE_REDUCTION", 32.0, 0.0, Integer.MAX_VALUE);
 
         builder.comment("The minimum damage that can be got in the Satiated Shield effect.");
-        SATIATED_SHIELD_MIN_DAMAGE = builder.defineInRange("SATIATED_SHIELD_MIN_DAMAGE", 16.0, 0.0, Integer.MAX_VALUE);
+        SATIATED_SHIELD_MIN_DAMAGE = builder.defineInRange("SATIATED_SHIELD_MIN_DAMAGE", 8.0, 0.0, Integer.MAX_VALUE);
 
         builder.comment("The multiplier for the exhaustion added per point of Satiated Shield Weakness Damage.");
         SATIATED_SHIELD_WEAKNESS_DAMAGE_MULTIPLIER = builder.defineInRange("SATIATED_SHIELD_WEAKNESS_DAMAGE_MULTIPLIER", 2.0, 1.0, Integer.MAX_VALUE);

--- a/src/main/java/com/github/ysbbbbbb/kaleidoscopecookery/config/GeneralConfig.java
+++ b/src/main/java/com/github/ysbbbbbb/kaleidoscopecookery/config/GeneralConfig.java
@@ -18,8 +18,9 @@ public class GeneralConfig {
     /**
      * 为饱腹代偿提供更一些精细的配置项。
      * 实际体验的效果为：
-     * 伤害不超过 最小伤害 时可以完全抗伤，只受到 最终伤害 * ( 1 - 伤害减免百分比 ) 的伤害；
      * 伤害不超过 最大伤害减免量 / 伤害减免百分比 时有 伤害减免百分比 的抗伤能力；
+     * 伤害不超过 最小伤害 时可以完全抗伤，只受到 最终伤害 * ( 1 - 伤害减免百分比 ) 的伤害，反之至少受到 最小伤害 的伤害；
+     * 伤害超过 最小伤害 一定区间时抗伤能力开始下降，最终伤害会逐渐趋近于 原始伤害 * ( 1 - 伤害减免百分比 )，但不会低于 最小伤害；
      * 伤害超过 最大伤害减免量 / 伤害减免百分比 时抗伤能力显著下降。
      */
     // 玩家处于饥饿状态效果时，饱腹代偿是否失效。
@@ -32,7 +33,13 @@ public class GeneralConfig {
     public static ForgeConfigSpec.DoubleValue SATIATED_SHIELD_DAMAGE_REDUCTION_PERCENT;
     // 饱腹代偿效果的最大伤害减免量，影响面对伤害较高时的抗伤表现，越高说明饱腹代偿的抗伤能力越强。
     public static ForgeConfigSpec.DoubleValue SATIATED_SHIELD_MAX_DAMAGE_REDUCTION;
-    // 饱腹代偿效果下可造成的最小伤害，影响面对伤害较低时的抗伤表现，越高说明饱腹代偿的抗伤能力越强。
+    /**
+     * 饱腹代偿效果下可造成的最小伤害；
+     * 原始伤害高于该值一定区间，会使得抗伤能力显著下降；
+     * 该值越高则抗伤下降的阈值越高，同时也会让超过该阈值的惩罚越严重。
+     * 因此该值越高说明饱腹代偿的抗伤能力越强，但过高可能会导致玩家在面对高伤害时受到过于严厉的惩罚。
+     * 该值为 0 则说明没有最小伤害限制，饱腹代偿的抗伤能力不会因为伤害过高而下降。
+     */
     public static ForgeConfigSpec.DoubleValue SATIATED_SHIELD_MIN_DAMAGE;
     // 当玩家受到饱腹代偿弱点伤害时，每点伤害增加的疲劳值的乘算倍率。
     public static ForgeConfigSpec.DoubleValue SATIATED_SHIELD_WEAKNESS_DAMAGE_MULTIPLIER;
@@ -60,10 +67,10 @@ public class GeneralConfig {
         SATIATED_SHIELD_DAMAGE_REDUCTION_PERCENT = builder.defineInRange("SATIATED_SHIELD_DAMAGE_REDUCTION_PERCENT", 1.0, 0.0, 1.0);
 
         builder.comment("The maximum damage reduction amount of the Satiated Shield effect.");
-        SATIATED_SHIELD_MAX_DAMAGE_REDUCTION = builder.defineInRange("SATIATED_SHIELD_MAX_DAMAGE_REDUCTION", 32.0, 0.0, Integer.MAX_VALUE);
+        SATIATED_SHIELD_MAX_DAMAGE_REDUCTION = builder.defineInRange("SATIATED_SHIELD_MAX_DAMAGE_REDUCTION", 64.0, 0.0, Integer.MAX_VALUE);
 
         builder.comment("The minimum damage that can be got in the Satiated Shield effect.");
-        SATIATED_SHIELD_MIN_DAMAGE = builder.defineInRange("SATIATED_SHIELD_MIN_DAMAGE", 8.0, 0.0, Integer.MAX_VALUE);
+        SATIATED_SHIELD_MIN_DAMAGE = builder.defineInRange("SATIATED_SHIELD_MIN_DAMAGE", 0.0, 0.0, Integer.MAX_VALUE);
 
         builder.comment("The multiplier for the exhaustion added per point of Satiated Shield Weakness Damage.");
         SATIATED_SHIELD_WEAKNESS_DAMAGE_MULTIPLIER = builder.defineInRange("SATIATED_SHIELD_WEAKNESS_DAMAGE_MULTIPLIER", 2.0, 1.0, Integer.MAX_VALUE);

--- a/src/main/java/com/github/ysbbbbbb/kaleidoscopecookery/event/effect/SatiatedShieldEvent.java
+++ b/src/main/java/com/github/ysbbbbbb/kaleidoscopecookery/event/effect/SatiatedShieldEvent.java
@@ -6,57 +6,84 @@ import com.github.ysbbbbbb.kaleidoscopecookery.init.ModEffects;
 import com.github.ysbbbbbb.kaleidoscopecookery.init.tag.TagMod;
 import net.minecraft.tags.DamageTypeTags;
 import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.effect.MobEffects;
 import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.event.entity.living.LivingDamageEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 
-import static com.github.ysbbbbbb.kaleidoscopecookery.config.GeneralConfig.SATIATED_SHIELD_ABSORB_EXCESS_DAMAGE;
+import static com.github.ysbbbbbb.kaleidoscopecookery.config.GeneralConfig.*;
 
 @Mod.EventBusSubscriber(modid = KaleidoscopeCookery.MOD_ID)
 public class SatiatedShieldEvent {
     @SubscribeEvent
     public static void onPlayerHurt(LivingDamageEvent event) {
-        // 1 伤害扣 2 Exhaustion
-        int amount = Math.round(event.getAmount()) * 2;
         DamageSource source = event.getSource();
         if (event.getEntity() instanceof Player player && !source.is(DamageTypeTags.BYPASSES_INVULNERABILITY)) {
             // 如果没有开启饱腹代偿，直接返回
             if (!GeneralConfig.SATIATED_SHIELD_ABSORB_ENABLED.get()) {
                 return;
             }
-
-            if (player.getFoodData().getFoodLevel() > 0 && player.hasEffect(ModEffects.SATIATED_SHIELD.get())) {
-                // 部分特殊伤害，扣除的 Exhaustion 翻倍
-                if (source.is(TagMod.SATIATED_SHIELD_WEAKNESS)) {
-                    amount *= 2;
-                }
-                // 原版是 4 点 Exhaustion 对应 1 点 Food Level
-                float exhaustionLevel = Math.max(0, amount / 4f);
-                float playerFoodLevel = player.getFoodData().getFoodLevel();
-                player.causeFoodExhaustion(exhaustionLevel);
-
-                if (SATIATED_SHIELD_ABSORB_EXCESS_DAMAGE.get()) {
-                    event.setCanceled(true);
-                } else {
-                    // 判断是否超出了玩家当前的 Food Level
-                    // 原版是 4 点 Exhaustion 对应 1 点 Food Level
-                    float consumedFoodLevel = exhaustionLevel / 4;
-                    if (consumedFoodLevel >= playerFoodLevel) {
-                        // 扣光了，施加额外伤害
-                        float extraDamage;
-                        if (source.is(TagMod.SATIATED_SHIELD_WEAKNESS)) {
-                            extraDamage = (consumedFoodLevel - playerFoodLevel) * 2;
-                        } else {
-                            extraDamage = (consumedFoodLevel - playerFoodLevel) * 4;
-                        }
-                        float remainingDamage = event.getAmount() - extraDamage;
-                        event.setAmount(Math.max(0, remainingDamage));
-                    } else {
-                        event.setAmount(0);
-                    }
-                }
+            // 如果不满足饱腹代偿的触发条件，直接返回
+            if (!isSatiatedShieldApply(player)) {
+                return;
             }
+
+            // 获取原始伤害
+            float originalDamage = event.getAmount();
+            // 计算最终伤害，同时将疲劳值增加到玩家身上
+            float finalDamage = calculateFinalDamage(player, source, originalDamage);
+            // 应用最终伤害
+            event.setAmount(finalDamage);
         }
+    }
+
+    // 判断玩家是否满足触发饱腹代偿效果的条件
+    public static boolean isSatiatedShieldApply(Player player) {
+        // 如果玩家处于饥饿状态且配置项启用，则不触发饱腹代偿效果
+        if (player.hasEffect(MobEffects.HUNGER) && IS_SATIATED_SHIELD_DISABLE_WHEN_HUNGRY_EFFECT.get()) {
+            return false;
+        }
+        // 只有当玩家的食物等级达到配置项设定的最低值且玩家具有饱腹代偿效果时，才触发饱腹代偿效果
+        return player.getFoodData().getFoodLevel() >= SATIATED_SHIELD_MIN_FOOD_LEVEL.get() && player.hasEffect(ModEffects.SATIATED_SHIELD.get());
+    }
+
+    // 计算最终伤害并增加疲劳值
+    public static float calculateFinalDamage(Player player, DamageSource source, float originalDamage) {
+        // 计算伤害减免量
+        float reducedDamage = (float) (originalDamage * SATIATED_SHIELD_DAMAGE_REDUCTION_PERCENT.get());
+        // 确保伤害减免量不超过最大值
+        if (reducedDamage > SATIATED_SHIELD_MAX_DAMAGE_REDUCTION.get()) {
+            reducedDamage = (float) (SATIATED_SHIELD_MAX_DAMAGE_REDUCTION.get() * 1f);
+        }
+        // 初步计算最终伤害
+        float finalDamage = originalDamage - reducedDamage;
+        // 当原始伤害高于可造成的最低伤害时，确保最终伤害不低于最小值
+        if (originalDamage > SATIATED_SHIELD_MIN_DAMAGE.get()) {
+            finalDamage = (float) Math.max(finalDamage, SATIATED_SHIELD_MIN_DAMAGE.get());
+            reducedDamage = originalDamage - finalDamage;
+        }
+        // 计算疲劳增加量
+        int exhaustionAmount = Math.toIntExact(Math.round(reducedDamage * SATIATED_SHIELD_ADDITIONAL_EXHAUSTION_PER_DAMAGE.get()));
+        // 如果伤害来源具有饱腹代偿弱点标签，增加疲劳增加量
+        if (source.is(TagMod.SATIATED_SHIELD_WEAKNESS)) {
+            exhaustionAmount *= SATIATED_SHIELD_WEAKNESS_DAMAGE_MULTIPLIER.get();
+        }
+        // 如果没有开启吸收过量伤害，直接返回最终伤害，否则计算吸收过量伤害后的最终伤害
+        if (!SATIATED_SHIELD_ABSORB_EXCESS_DAMAGE.get()) {
+            // foodLevel * 4 = Exhaustion，Exhaustion = Damage * 每点伤害的消耗量
+            float absorbedDamage = (float) (player.getFoodData().getFoodLevel() * 4 /  SATIATED_SHIELD_DAMAGE_REDUCTION_PERCENT.get());
+            // 如果伤害来源具有饱腹代偿弱点标签，说明增加了更多的Exhaustion，因此除以弱点倍率来计算实际吸收的伤害。
+            if (source.is(TagMod.SATIATED_SHIELD_WEAKNESS)) {
+                absorbedDamage /= SATIATED_SHIELD_WEAKNESS_DAMAGE_MULTIPLIER.get();
+            }
+            // 过量伤害 = 减免伤害 - 吸收伤害，最终伤害应加上此处的过量伤害
+            finalDamage += Math.max(0, reducedDamage - absorbedDamage);
+        }
+        // 将疲劳增加量应用到玩家身上
+        float exhaustion = Math.max(0, exhaustionAmount);
+        player.causeFoodExhaustion(exhaustion);
+        // 返回最终伤害
+        return finalDamage;
     }
 }


### PR DESCRIPTION
# 修改摘要
- GeneralConfig.java
  - 添加了7个饱腹代偿的配置项。
- SatiatedShieldEvent.java
  - 将配置项融入事件逻辑，顺带修复了 #171 

# 详细内容
添加了如下的配置项。
```java
    /**
     * 为饱腹代偿提供更一些精细的配置项。
     * 实际体验的效果为：
     * 伤害不超过 最大伤害减免量 / 伤害减免百分比 时有 伤害减免百分比 的抗伤能力；
     * 伤害不超过 最小伤害 时可以完全抗伤，只受到 最终伤害 * ( 1 - 伤害减免百分比 ) 的伤害，反之至少受到 最小伤害 的伤害；
     * 伤害超过 最小伤害 一定区间时抗伤能力开始下降，最终伤害会逐渐趋近于 原始伤害 * ( 1 - 伤害减免百分比 )，但不会低于 最小伤害；
     * 伤害超过 最大伤害减免量 / 伤害减免百分比 时抗伤能力显著下降。
     */
    // 玩家处于饥饿状态效果时，饱腹代偿是否失效。
    public static ForgeConfigSpec.BooleanValue IS_SATIATED_SHIELD_DISABLE_WHEN_HUNGRY_EFFECT;
    // 触发饱腹代偿效果所需的最小食物等级，越高说明饱腹代偿的触发条件越苛刻。
    public static ForgeConfigSpec.IntValue SATIATED_SHIELD_MIN_FOOD_LEVEL;
    // 饱腹代偿每吸收一点伤害所需的基础 Exhaustion 数值。
    public static ForgeConfigSpec.DoubleValue SATIATED_SHIELD_ADDITIONAL_EXHAUSTION_PER_DAMAGE;
    // 饱腹代偿效果的伤害减免百分比，不满 1 则必定会受到一部分伤害，越高说明饱腹代偿的抗伤能力越强。
    public static ForgeConfigSpec.DoubleValue SATIATED_SHIELD_DAMAGE_REDUCTION_PERCENT;
    // 饱腹代偿效果的最大伤害减免量，影响面对伤害较高时的抗伤表现，越高说明饱腹代偿的抗伤能力越强。
    public static ForgeConfigSpec.DoubleValue SATIATED_SHIELD_MAX_DAMAGE_REDUCTION;
    /**
     * 饱腹代偿效果下可造成的最小伤害；
     * 原始伤害高于该值一定区间，会使得抗伤能力显著下降；
     * 该值越高则抗伤下降的阈值越高，同时也会让超过该阈值的惩罚越严重。
     * 因此该值越高说明饱腹代偿的抗伤能力越强，但过高可能会导致玩家在面对高伤害时受到过于严厉的惩罚。
     * 该值为 0 则说明没有最小伤害限制，饱腹代偿的抗伤能力不会因为伤害过高而下降。
     */
    public static ForgeConfigSpec.DoubleValue SATIATED_SHIELD_MIN_DAMAGE;
    // 当玩家受到饱腹代偿弱点伤害时，每点伤害增加的疲劳值的乘算倍率。
    public static ForgeConfigSpec.DoubleValue SATIATED_SHIELD_WEAKNESS_DAMAGE_MULTIPLIER;
```
我曾将这部分修改使用mixin实现，并单独打包成一个mod发布。
因此，使用这些配置项的大致计算逻辑，您可以从我的项目的[README](https://github.com/ShrHang/Kaleidoscope-Cookery-Satiated-Shield-Tuner/blob/master/README-CN.md)中初步了解到。